### PR TITLE
add compare config

### DIFF
--- a/src/XlsxCompare.Tests/CompareOptionsTests.cs
+++ b/src/XlsxCompare.Tests/CompareOptionsTests.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace XlsxCompare.Tests
+{
+    [TestClass]
+    public class CompareOptionsTests
+    {
+
+        [TestMethod]
+        [DataRow(@"{}", nameof(CompareOptions.LeftKeyColumn))]
+        [DataRow(@"{'LeftKeyColumn': ''}", nameof(CompareOptions.LeftKeyColumn))]
+        [DataRow(@"{'LeftKeyColumn': '  '}", nameof(CompareOptions.LeftKeyColumn))]
+        [DataRow(@"{'LeftKeyColumn': 'ok'}", nameof(CompareOptions.RightKeyColumn))]
+        [DataRow(@"{'LeftKeyColumn': 'ok', 'RightKeyColumn': 'ok'}", nameof(CompareOptions.Assertions))]
+        [DataRow(@"{'LeftKeyColumn': 'ok', 'RightKeyColumn': 'ok', 'Assertions':[]}", nameof(CompareOptions.Assertions))]
+        [DataRow(@"{'LeftKeyColumn': 'ok', 'RightKeyColumn': 'ok', 'Assertions':[{}]}", nameof(Assertion.LeftColumnName))]
+        [DataRow(@"{'LeftKeyColumn': 'ok', 'RightKeyColumn': 'ok', 'Assertions':[{'LeftColumnName': 'ok'}]}", nameof(Assertion.RightColumnName))]
+        public void FromJson_MissingData_Throws(string json, string missingField)
+        {
+            var ex = Assert.ThrowsException<InvalidOperationException>(
+                () => CompareOptions.FromJson(json.Replace('\'', '"'))
+            );
+
+            StringAssert.Contains(ex.Message, missingField);
+        }
+
+        [TestMethod]
+        public void FromJson_ValidData_Parses()
+        {
+            var expected = new CompareOptions("leftKey", "rightKey", new[]{
+                new Assertion("leftCol", "rightCol", null),
+                new Assertion("leftCol2", "rightCol2", MatchBy.None)
+            });
+
+            var json = @"{
+                'leftKeyColumn': 'leftKey',
+                'rightKeyColumn': 'rightKey',
+                'assertions':[
+                    {'LeftColumnName': 'leftCol', 'RightColumnName': 'rightCol'},
+                    {'leftColumnName': 'leftCol2', 'rightColumnName': 'rightCol2', 'matchBy': 'none'}
+                ]
+            }".Replace('\'', '"');
+
+            var actual = CompareOptions.FromJson(json);
+            Assert.AreEqual(expected.LeftKeyColumn, actual.LeftKeyColumn);
+            Assert.AreEqual(expected.RightKeyColumn, actual.RightKeyColumn);
+            CollectionAssert.AreEqual(
+                expected.Assertions.ToArray(),
+                actual.Assertions.ToArray()
+            );
+        }
+    }
+}

--- a/src/XlsxCompare/Assertion.cs
+++ b/src/XlsxCompare/Assertion.cs
@@ -1,0 +1,4 @@
+namespace XlsxCompare
+{
+    record Assertion(string LeftColumnName, string RightColumnName, MatchBy? MatchBy);
+}

--- a/src/XlsxCompare/CompareOptions.cs
+++ b/src/XlsxCompare/CompareOptions.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace XlsxCompare
+{
+    record CompareOptions(string LeftKeyColumn, string RightKeyColumn, IReadOnlyCollection<Assertion> Assertions)
+    {
+        public static CompareOptions FromJsonFile(string path) => FromJson(File.ReadAllText(path));
+
+        public static CompareOptions FromJson(string json)
+        {
+            var jsonOpts = new JsonSerializerOptions
+            {
+                PropertyNameCaseInsensitive = true,
+                AllowTrailingCommas = true,
+            };
+            jsonOpts.Converters.Add(new JsonStringEnumConverter());
+
+            var opts = JsonSerializer.Deserialize<CompareOptions>(json, jsonOpts)
+                ?? throw new InvalidOperationException("failed");
+
+            // `Deserialize` doesn't respect non-null strings, validate
+            if (string.IsNullOrWhiteSpace(opts.LeftKeyColumn)) { throw new InvalidOperationException($"missing {nameof(LeftKeyColumn)}"); }
+            if (string.IsNullOrWhiteSpace(opts.RightKeyColumn)) { throw new InvalidOperationException($"missing {nameof(RightKeyColumn)}"); }
+            if (opts.Assertions == null || opts.Assertions.Count == 0) { throw new InvalidOperationException($"missing {nameof(Assertions)}"); }
+            foreach (var (left, right, matchBy) in opts.Assertions)
+            {
+                if (string.IsNullOrWhiteSpace(left)) { throw new InvalidOperationException($"missing {nameof(Assertion.LeftColumnName)}"); }
+                if (string.IsNullOrWhiteSpace(right)) { throw new InvalidOperationException($"missing {nameof(Assertion.RightColumnName)}"); }
+            }
+
+            return opts;
+        }
+    };
+}

--- a/src/XlsxCompare/MatchBy.cs
+++ b/src/XlsxCompare/MatchBy.cs
@@ -1,0 +1,7 @@
+namespace XlsxCompare
+{
+    enum MatchBy
+    {
+        None = 0,
+    }
+}

--- a/src/XlsxCompare/XlsxCompare.csproj
+++ b/src/XlsxCompare/XlsxCompare.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
+    <PackageReference Include="System.Text.Json" Version="5.0.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This is going to come from a CLI parameter, so get setup to parse directly instead of trying to shoe-horn through `IConfiguration`

Fighting nullable reference types a little; `System.Text.Json` has no runtime knowledge of what is a nullable string and what is required. Had to add some direct validation.

System.Text.Json also does not respect single quoted json (which is non-standard), so the tests mess with strings more than I'd like to keep it readable..