### PR TITLE
centralize data modifications in `Assertion`

### DIFF
--- a/src/XlsxCompare.Tests/AssertionTests.cs
+++ b/src/XlsxCompare.Tests/AssertionTests.cs
@@ -19,6 +19,16 @@ namespace XlsxCompare.Tests
                 "a asdf",
                 "asdf a"
             };
+            yield return new object[]{
+                new Assertion("leftCol", "rightCol", ZeroRepresentsEmpty: true),
+                "0",
+                ""
+            };
+            yield return new object[]{
+                new Assertion("leftCol", "rightCol", ZeroRepresentsEmpty: true),
+                "",
+                "0.00"
+            };
         }
 
         [TestMethod]
@@ -39,6 +49,16 @@ namespace XlsxCompare.Tests
                 new Assertion("leftCol", "rightCol", Remove: "asdf"),
                 "a asdf",
                 "asdf b"
+            };
+            yield return new object[]{
+                new Assertion("leftCol", "rightCol", ZeroRepresentsEmpty: true),
+                "",
+                "0.001"
+            };
+            yield return new object[]{
+                new Assertion("leftCol", "rightCol", ZeroRepresentsEmpty: true),
+                "1",
+                "0"
             };
         }
         [TestMethod]

--- a/src/XlsxCompare.Tests/MatchByTests.cs
+++ b/src/XlsxCompare.Tests/MatchByTests.cs
@@ -17,10 +17,6 @@ namespace XlsxCompare.Tests
         [DataRow(MatchBy.Date, "2021-04-01", "04/01/2021")]
         [DataRow(MatchBy.Date, "2021-04-01 4:00AM", "04/01/2021")]
         [DataRow(MatchBy.StringLeftStartsWithRight, "asdf", "as")]
-        [DataRow(MatchBy.ZeroRepresentsEmpty, "0", "")]
-        [DataRow(MatchBy.ZeroRepresentsEmpty, "", "0")]
-        [DataRow(MatchBy.ZeroRepresentsEmpty, "0.00", "")]
-        [DataRow(MatchBy.ZeroRepresentsEmpty, "", "0.00")]
         [DataRow(MatchBy.Decimal, "0.084400", "0.0844")]
         [DataRow(MatchBy.Decimal, "0.00", "0")]
         public void IsMatch_ThingsThatMatch_ReturnsTrue(MatchBy? match, string left, string right)
@@ -37,7 +33,6 @@ namespace XlsxCompare.Tests
         [DataRow(MatchBy.Date, "2021-04-01", "04/02/2021")]
         [DataRow(MatchBy.StringLeftStartsWithRight, "as", "asdf")]
         [DataRow(MatchBy.StringLeftStartsWithRight, "asdf", "")]
-        [DataRow(MatchBy.ZeroRepresentsEmpty, "0", "1")]
         [DataRow(MatchBy.Decimal, "0.084400", "0.0845")]
         public void IsMatch_ThingsThatDoNotMatch_ReturnsFalse(MatchBy? match, string left, string right)
         {

--- a/src/XlsxCompare/Assertion.cs
+++ b/src/XlsxCompare/Assertion.cs
@@ -4,7 +4,9 @@ namespace XlsxCompare
         string LeftColumnName,
         string RightColumnName,
         MatchBy? MatchBy = null,
-        string? Remove = null)
+        string? Remove = null,
+        bool ZeroRepresentsEmpty = false
+        )
     {
         public bool IsMatch(string left, string right)
         {
@@ -13,7 +15,17 @@ namespace XlsxCompare
                 left = left.Replace(Remove, "").Trim();
                 right = right.Replace(Remove, "").Trim();
             }
+            if (ZeroRepresentsEmpty)
+            {
+                left = NormalizeZeroToEmpty(left);
+                right = NormalizeZeroToEmpty(right);
+            }
             return MatchBy.IsMatch(left, right);
         }
+
+        private static string NormalizeZeroToEmpty(string input)
+            => decimal.TryParse(input, out var parsed) && parsed == 0
+                ? ""
+                : input;
     };
 }

--- a/src/XlsxCompare/MatchBy.cs
+++ b/src/XlsxCompare/MatchBy.cs
@@ -11,8 +11,6 @@ namespace XlsxCompare
         Decimal,
         Date,
         StringLeftStartsWithRight,
-        ZeroRepresentsEmpty,
-        DecimalZeroRepresentsEmpty,
     }
 
     static class MatchByExtensions
@@ -20,8 +18,6 @@ namespace XlsxCompare
         public static bool IsMatch(this MatchBy? match, string left, string right)
             => match switch
             {
-                MatchBy.ZeroRepresentsEmpty => IsStringMatch(NormalizeZeroToEmpty(left), NormalizeZeroToEmpty(right)),
-                MatchBy.DecimalZeroRepresentsEmpty => IsDecimalMatch(NormalizeZeroToEmpty(left), NormalizeZeroToEmpty(right)),
                 MatchBy.Date => IsDateMatch(left, right),
                 MatchBy.Integer => IsIntegerMatch(left, right),
                 MatchBy.StringIgnoreMissingLeft => left.Length == 0 || IsStringMatch(left, right),
@@ -48,11 +44,6 @@ namespace XlsxCompare
         private static bool IsLeftStartsWithRightMatch(string left, string right)
             => right.Length > 0
                 && left.StartsWith(right, StringComparison.OrdinalIgnoreCase);
-
-        private static string NormalizeZeroToEmpty(string input)
-            => decimal.TryParse(input, out var parsed) && parsed == 0
-                ? ""
-                : input;
 
         private static bool IsDecimalMatch(string left, string right)
             => IsStringMatch(left, right)


### PR DESCRIPTION
This way we can compose modifications with matching schemes, and avoid  combinatorial explosion in `MatchBy`.