### PR TITLE
add release tag CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,26 +24,3 @@ jobs:
           project_path: ${{ env.SLN }}
           set_check_status_from_test_outcome: true
           github_token: ${{ secrets.GITHUB_TOKEN }}
-  binaries:
-    needs: build
-    runs-on: ubuntu-latest
-    if: ${{ github.ref == 'refs/heads/main' }}
-    name: create standalone binaries
-    strategy:
-      matrix:
-        rid:
-          - win-x64
-          - linux-x64
-          - osx-x64
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: "5.0.x"
-      - name: Create the self-contained binary
-        run: dotnet build --configuration Release "${APP}" -r ${{ matrix.rid }} -o out/${{ matrix.rid }}
-      - name: Upload artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: ${{ matrix.rid }} binary
-          path: out/${{ matrix.rid }}/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           dotnet-version: "5.0.x"
       - name: Create the self-contained binary
-        run: dotnet build --configuration Release "${APP}" -r ${{ matrix.rid }} -o out/${{ matrix.rid }} --self-contained true
+        run: dotnet publish --configuration Release "${APP}" -r ${{ matrix.rid }} -o out/${{ matrix.rid }} --self-contained true
       - name: Upload artifact
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,6 +59,7 @@ jobs:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
           draft: true
           title: "testing ${{ github.run_id }}"
+          automatic_release_tag: "testing"
           prerelease: false
           files: |
             out/**/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,8 +28,8 @@ jobs:
       matrix:
         rid:
           - win-x64
+          - linux-x64
           # TODO: uncomment before finishing experiments
-          # - linux-x64
           # - osx-x64
     steps:
       - uses: actions/checkout@v2
@@ -38,11 +38,13 @@ jobs:
           dotnet-version: "5.0.x"
       - name: Create the self-contained binary
         run: dotnet publish --configuration Release "${APP}" -r ${{ matrix.rid }} -o out/${{ matrix.rid }} --self-contained true
+      - name: rename to include rid
+        run: cp out/${{ matrix.rid }}/XlsxCompare XlsxCompare-${{ matrix.rid }} || cp out/${{ matrix.rid }}/XlsxCompare.exe XlsxCompare-${{ matrix.rid }}.exe .
       - name: Upload artifact
         uses: actions/upload-artifact@v2
         with:
           name: ${{ matrix.rid }} binary
-          path: out/${{ matrix.rid }}/*
+          path: XlsxCompare*
 
   release:
     needs: binaries
@@ -62,4 +64,4 @@ jobs:
           automatic_release_tag: "testing"
           prerelease: false
           files: |
-            out/**/*
+            XlsxCompare*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,5 @@
 name: Release
 
-# https://acraven.medium.com/a-nuget-package-workflow-using-github-actions-7da8c6557863
 on:
   pull_request:
   push:
@@ -50,12 +49,15 @@ jobs:
     steps:
       - name: download all binaries
         uses: actions/download-artifact@v2
+        with:
+          path: out
       - name: Display structure of downloaded files
         run: ls -R
-      # - uses: "marvinpinto/action-automatic-releases@v1"
-      #   with:
-      #     repo_token: "${{ secrets.GITHUB_TOKEN }}"
-      #     prerelease: false
-      #     files: |
-      #       LICENSE.txt
-      #       *.jar
+      - uses: "marvinpinto/action-automatic-releases@v1"
+        with:
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          draft: true
+          title: "testing ${{ github.run_id }}"
+          prerelease: false
+          files: |
+            out/**/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Create the self-contained binary
         run: dotnet publish --configuration Release "${APP}" -r ${{ matrix.rid }} -o out/${{ matrix.rid }} --self-contained true
       - name: rename to include rid
-        run: cp out/${{ matrix.rid }}/XlsxCompare XlsxCompare-${{ matrix.rid }} || cp out/${{ matrix.rid }}/XlsxCompare.exe XlsxCompare-${{ matrix.rid }}.exe .
+        run: cp out/${{ matrix.rid }}/XlsxCompare XlsxCompare-${{ matrix.rid }} || cp out/${{ matrix.rid }}/XlsxCompare.exe XlsxCompare-${{ matrix.rid }}.exe
       - name: Upload artifact
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,6 @@
 name: Release
 
 on:
-  pull_request:
   push:
     tags:
       - "v*"
@@ -10,18 +9,18 @@ env:
   APP: "./src/XlsxCompare"
 
 jobs:
-  # verify_commit:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v2
-  #     - name: Verify commit exists in origin/main
-  #       run: |
-  #         git fetch --no-tags --prune --depth=1 origin +refs/heads/*:refs/remotes/origin/*
-  #         git branch --remote --contains | grep origin/main
+  verify_commit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Verify commit exists in origin/main
+        run: |
+          git fetch --no-tags --prune --depth=1 origin +refs/heads/*:refs/remotes/origin/*
+          git branch --remote --contains | grep origin/main
 
   binaries:
-    #    needs: verify_commit
+    needs: verify_commit
     runs-on: ubuntu-latest
     name: create standalone binaries
     strategy:
@@ -29,8 +28,7 @@ jobs:
         rid:
           - win-x64
           - linux-x64
-          # TODO: uncomment before finishing experiments
-          # - osx-x64
+          - osx-x64
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-dotnet@v1
@@ -38,7 +36,7 @@ jobs:
           dotnet-version: "5.0.x"
       - name: Create the self-contained binary
         run: dotnet publish --configuration Release "${APP}" -r ${{ matrix.rid }} -o out/${{ matrix.rid }} --self-contained true
-      - name: rename to include rid
+      - name: rename so the release can have a flat list of files
         run: cp out/${{ matrix.rid }}/XlsxCompare XlsxCompare-${{ matrix.rid }} || cp out/${{ matrix.rid }}/XlsxCompare.exe XlsxCompare-${{ matrix.rid }}.exe
       - name: Upload artifact
         uses: actions/upload-artifact@v2
@@ -52,14 +50,9 @@ jobs:
     steps:
       - name: download all binaries
         uses: actions/download-artifact@v2
-      - name: Display structure of downloaded files
-        run: ls -R
       - uses: "marvinpinto/action-automatic-releases@v1.1.1"
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
-          draft: true
-          title: "testing ${{ github.run_id }}"
-          automatic_release_tag: "testing"
           prerelease: false
           files: |
             **/XlsxCompare*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,8 +52,6 @@ jobs:
     steps:
       - name: download all binaries
         uses: actions/download-artifact@v2
-        with:
-          path: out
       - name: Display structure of downloaded files
         run: ls -R
       - uses: "marvinpinto/action-automatic-releases@v1.1.1"
@@ -64,4 +62,4 @@ jobs:
           automatic_release_tag: "testing"
           prerelease: false
           files: |
-            XlsxCompare*
+            **/XlsxCompare*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           dotnet-version: "5.0.x"
       - name: Create the self-contained binary
-        run: dotnet build --configuration Release "${APP}" -r ${{ matrix.rid }} -o out/${{ matrix.rid }}
+        run: dotnet build --configuration Release "${APP}" -r ${{ matrix.rid }} -o out/${{ matrix.rid }} --self-contained true
       - name: Upload artifact
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,8 +28,9 @@ jobs:
       matrix:
         rid:
           - win-x64
-          - linux-x64
-          - osx-x64
+          # TODO: uncomment before finishing experiments
+          # - linux-x64
+          # - osx-x64
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-dotnet@v1
@@ -53,7 +54,7 @@ jobs:
           path: out
       - name: Display structure of downloaded files
         run: ls -R
-      - uses: "marvinpinto/action-automatic-releases@v1"
+      - uses: "marvinpinto/action-automatic-releases@v1.1.1"
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
           draft: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,61 @@
+name: Release
+
+# https://acraven.medium.com/a-nuget-package-workflow-using-github-actions-7da8c6557863
+on:
+  pull_request:
+  push:
+    tags:
+      - "v*"
+
+env:
+  APP: "./src/XlsxCompare"
+
+jobs:
+  # verify_commit:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v2
+  #     - name: Verify commit exists in origin/main
+  #       run: |
+  #         git fetch --no-tags --prune --depth=1 origin +refs/heads/*:refs/remotes/origin/*
+  #         git branch --remote --contains | grep origin/main
+
+  binaries:
+    #    needs: verify_commit
+    runs-on: ubuntu-latest
+    name: create standalone binaries
+    strategy:
+      matrix:
+        rid:
+          - win-x64
+          - linux-x64
+          - osx-x64
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: "5.0.x"
+      - name: Create the self-contained binary
+        run: dotnet build --configuration Release "${APP}" -r ${{ matrix.rid }} -o out/${{ matrix.rid }}
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ matrix.rid }} binary
+          path: out/${{ matrix.rid }}/*
+
+  release:
+    needs: binaries
+    runs-on: ubuntu-latest
+    steps:
+      - name: download all binaries
+        uses: actions/download-artifact@v2
+      - name: Display structure of downloaded files
+        run: ls -R
+      # - uses: "marvinpinto/action-automatic-releases@v1"
+      #   with:
+      #     repo_token: "${{ secrets.GITHUB_TOKEN }}"
+      #     prerelease: false
+      #     files: |
+      #       LICENSE.txt
+      #       *.jar

--- a/src/XlsxCompare/XlsxCompare.csproj
+++ b/src/XlsxCompare/XlsxCompare.csproj
@@ -8,7 +8,6 @@
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <PublishSingleFile>true</PublishSingleFile>
-    <SelfContained>true</SelfContained>
     <PublishTrimmed>true</PublishTrimmed>
     <IncludeAllContentForSelfExtract>true</IncludeAllContentForSelfExtract>
     <DebugType>embedded</DebugType>


### PR DESCRIPTION
Build binaries when we make a release tag, and publish those on a github release.

This will let people without github accounts download and use the CLI, currently workflow artifacts are only available to logged-in users: https://github.com/actions/upload-artifact/issues/51

Also fixes a bug in the binary CI to actually make one-file binaries instead of 256 `dll`s.