### PR TITLE
bugfix *StartsWith* matchers

### DIFF
--- a/src/XlsxCompare.Tests/MatchByTests.cs
+++ b/src/XlsxCompare.Tests/MatchByTests.cs
@@ -17,9 +17,11 @@ namespace XlsxCompare.Tests
         [DataRow(MatchBy.Date, "2021-04-01", "04/01/2021")]
         [DataRow(MatchBy.Date, "2021-04-01 4:00AM", "04/01/2021")]
         [DataRow(MatchBy.StringLeftStartsWithRight, "asdf", "as")]
+        [DataRow(MatchBy.StringLeftStartsWithRight, "", "")]
         [DataRow(MatchBy.Decimal, "0.084400", "0.0844")]
         [DataRow(MatchBy.Decimal, "0.00", "0")]
         [DataRow(MatchBy.StringRightStartsWithLeft, "asdf", "asdf and then some")]
+        [DataRow(MatchBy.StringRightStartsWithLeft, "", "")]
         public void IsMatch_ThingsThatMatch_ReturnsTrue(MatchBy? match, string left, string right)
         {
             Assert.IsTrue(match.IsMatch(left, right));

--- a/src/XlsxCompare/MatchBy.cs
+++ b/src/XlsxCompare/MatchBy.cs
@@ -44,8 +44,12 @@ namespace XlsxCompare
                     && leftDate.Date == rightDate.Date);
 
         private static bool IsLeftStartsWithRightMatch(string left, string right)
-            => right.Length > 0
-                && left.StartsWith(right, StringComparison.OrdinalIgnoreCase);
+            => (left, right) switch
+            {
+                ("", "") => true, // both empty is a match
+                (_, "") => false, // left starting with empty doesn't count
+                (_, _) => left.StartsWith(right, StringComparison.OrdinalIgnoreCase),
+            };
 
         private static bool IsDecimalMatch(string left, string right)
             => IsStringMatch(left, right)


### PR DESCRIPTION
Bad handling of empty / null resulted in `""` not matching `""`