### PR TITLE
bugfix `token` match

### DIFF
--- a/src/XlsxCompare.Tests/MatchByTests.cs
+++ b/src/XlsxCompare.Tests/MatchByTests.cs
@@ -25,6 +25,7 @@ namespace XlsxCompare.Tests
         [DataRow(MatchBy.Tokens, "X Y", "Y X")]
         [DataRow(MatchBy.Tokens, "X Y Z", "  Z X   Y")]
         [DataRow(MatchBy.Tokens, "", "")]
+        [DataRow(MatchBy.Tokens, "X  Y Z", "X Y Z")]
         public void IsMatch_ThingsThatMatch_ReturnsTrue(MatchBy? match, string left, string right)
         {
             Assert.IsTrue(match.IsMatch(left, right));
@@ -44,6 +45,7 @@ namespace XlsxCompare.Tests
         [DataRow(MatchBy.StringRightStartsWithLeft, "asdf but no", "asdf and then some")]
         [DataRow(MatchBy.Tokens, "X Y", "Y Z")]
         [DataRow(MatchBy.Tokens, "X", "  ")]
+        [DataRow(MatchBy.Tokens, "X Y Z", "X Y Z AA")]
         public void IsMatch_ThingsThatDoNotMatch_ReturnsFalse(MatchBy? match, string left, string right)
         {
             Assert.IsFalse(match.IsMatch(left, right));

--- a/src/XlsxCompare/MatchBy.cs
+++ b/src/XlsxCompare/MatchBy.cs
@@ -62,12 +62,11 @@ namespace XlsxCompare
                     && leftInt == rightInt);
 
         private static bool IsTokenMatch(string left, string right)
-            => IsTokenMatch(Tokenize(left), Tokenize(right));
+            => Tokenize(left).SetEquals(Tokenize(right));
 
-        private static bool IsTokenMatch(IEnumerable<string> left, IEnumerable<string> right)
-            => !left.Except(right, StringComparer.OrdinalIgnoreCase).Any();
-
-        private static IEnumerable<string> Tokenize(string value)
-            => value.Split(' ').Select(x => x.Trim());
+        private static ISet<string> Tokenize(string value)
+            => new HashSet<string>(
+                value.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries),
+                StringComparer.OrdinalIgnoreCase);
     }
 }


### PR DESCRIPTION
Had issues with spaces and the matcher wasn't equality; it was effectively an `IsSubset`