### PR TITLE
treat missing rows as a mismatch

### DIFF
--- a/src/XlsxCompare.Tests/XlsxComparerTests.cs
+++ b/src/XlsxCompare.Tests/XlsxComparerTests.cs
@@ -61,5 +61,55 @@ namespace XlsxCompare.Tests
                 Assert.AreEqual(expectedContext[id], newId);
             }
         }
+
+        [TestMethod]
+        public void Compare_NoJoinMatchesWithContext_ReturnsMissingDataAsMismatch()
+        {
+            var opts = new CompareOptions(
+                LeftKeyColumn: "id",
+                RightKeyColumn: "new_id",
+                new[]{
+                    new Assertion("Email", "EML")
+                },
+                new ResultOptions(
+                    LeftColumnNames: new[] { "Name" }
+                )
+            );
+            var results = _comparer.Compare("left.xlsx", "right.xlsx", opts);
+
+            Assert.AreEqual(3, results.TotalCellMismatches);
+            Assert.AreEqual(3, results.TotalRowMismatches);
+
+            var expectedContext = new Dictionary<string, string>(){
+                {"1", "leading trailing spaces"},
+                {"2", "null email"},
+                {"3", "whitespace address"}
+            };
+
+            foreach (var mismatch in results.Mismatches)
+            {
+                var id = mismatch.Key;
+                var name = mismatch.Context["Name"];
+                Assert.AreEqual(expectedContext[id], name);
+            }
+        }
+
+        [TestMethod]
+        public void Compare_NoJoinMatchesWithIgnoringMissingRows_ReturnsNoMismatches()
+        {
+            var opts = new CompareOptions(
+                LeftKeyColumn: "id",
+                RightKeyColumn: "new_id",
+                Assertions: new[]{
+                    new Assertion("Email", "EML")
+                },
+                ResultOptions: new ResultOptions(),
+                IgnoreMissingRows: true
+            );
+            var results = _comparer.Compare("left.xlsx", "right.xlsx", opts);
+
+            Assert.AreEqual(0, results.TotalCellMismatches);
+            Assert.AreEqual(0, results.TotalRowMismatches);
+        }
     }
 }

--- a/src/XlsxCompare/Mismatch.cs
+++ b/src/XlsxCompare/Mismatch.cs
@@ -6,7 +6,7 @@ namespace XlsxCompare
         Assertion Assertion,
         string Key,
         string LeftValue,
-        string RightValue,
+        string? RightValue,
         IReadOnlyDictionary<string, string> Context
     );
 }

--- a/src/XlsxCompare/ResultsWriter.cs
+++ b/src/XlsxCompare/ResultsWriter.cs
@@ -57,11 +57,11 @@ namespace XlsxCompare
             yield return opts.RightValueHeader;
         }
 
-        private static IEnumerable<string> GetValues(ResultOptions opts, Mismatch mismatch)
+        private static IEnumerable<string?> GetValues(ResultOptions opts, Mismatch mismatch)
         {
             foreach (var col in opts.ContextColumnNames)
             {
-                yield return mismatch.Context[col];
+                yield return mismatch.Context.GetValueOrDefault(col);
             }
             yield return mismatch.Assertion.LeftColumnName;
             // TODO: maybe format?
@@ -69,7 +69,7 @@ namespace XlsxCompare
             yield return mismatch.RightValue;
         }
 
-        private static void WriteRow(ExcelWorksheet sheet, int row, IEnumerable<string> values)
+        private static void WriteRow(ExcelWorksheet sheet, int row, IEnumerable<string?> values)
         {
             var col = 1;
             foreach (var value in values)


### PR DESCRIPTION
Throwing `KeyNotFound` is not helpful for larger analsyis.

Had to loosed a lot of non-null strings because we won't have any context from the "right" file, so need to pass some more nulls around when building output.